### PR TITLE
move system defaults into main()

### DIFF
--- a/Ohce/tastapod/Ohce/src/main/kotlin/Main.kt
+++ b/Ohce/tastapod/Ohce/src/main/kotlin/Main.kt
@@ -1,5 +1,7 @@
+import ohce.now
 import ohce.ohceSession
+import java.io.PrintWriter
 
 fun main(args: Array<String>) {
-    ohceSession(args[0])
+    ohceSession(args[0], now(), generateSequence { readLine() }, PrintWriter(System.out, true))
 }

--- a/Ohce/tastapod/Ohce/src/main/kotlin/ohce/Ohce.kt
+++ b/Ohce/tastapod/Ohce/src/main/kotlin/ohce/Ohce.kt
@@ -7,7 +7,7 @@ data class Time(val hour: Int, val minute: Int = 0)
 
 fun now() = LocalDateTime.now().run { Time(hour = hour, minute = minute) }
 
-fun sayHello(name: String, time: Time = now(), output: PrintWriter) {
+fun sayHello(name: String, time: Time, output: PrintWriter) {
     val greeting = when (time.hour) {
         in 20..23, in 0..5 -> "Buenas noches"
         in 12..19 -> "Buenas tardes"
@@ -26,12 +26,7 @@ fun isStop(input: String) = input == "Stop!"
 fun sayGoodbye(name: String, output: PrintWriter) =
     output.print("Adios $name")
 
-fun ohceSession(
-    name: String,
-    time: Time = now(),
-    input: Sequence<String> = generateSequence { readLine() },
-    output: PrintWriter = PrintWriter(System.out, true) //autoflush
-) {
+fun ohceSession(name: String, time: Time, input: Sequence<String>, output: PrintWriter) {
     fun println(fn: () -> Unit) = output.run { fn(); println() }
 
     // start


### PR DESCRIPTION
The CLI defaults like writing to `System.out` or using the system clock were hidden in the ohce implementation. Now they are in the `main()` function and there are no defaults on the ohce functions themselves.